### PR TITLE
feat: fail cli run on test failures

### DIFF
--- a/sg/internal/cli/test/app.go
+++ b/sg/internal/cli/test/app.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -14,6 +15,8 @@ import (
 	"github.com/Azure/ShieldGuard/sg/internal/utils"
 	"github.com/spf13/pflag"
 )
+
+var errTestFailure = errors.New("test failed")
 
 type failSettings struct {
 	noFail         bool
@@ -46,7 +49,10 @@ func (s *failSettings) CheckQueryResults(results []result.QueryResults) error {
 		return nil
 	}
 
-	err := fmt.Errorf("found %d failure(s), %d warning(s)", countFailures, countWarnings)
+	err := fmt.Errorf(
+		"%w: found %d failure(s), %d warning(s)",
+		errTestFailure, countFailures, countWarnings,
+	)
 	if countFailures > 0 {
 		return err
 	}

--- a/sg/internal/cli/test/app_test.go
+++ b/sg/internal/cli/test/app_test.go
@@ -95,6 +95,7 @@ func Test_failSettings_CheckQueryResults(t *testing.T) {
 			err := c.failSettings.CheckQueryResults(c.results)
 			if c.expectErr {
 				assert.Error(t, err)
+				assert.ErrorIs(t, err, errTestFailure)
 			} else {
 				assert.NoError(t, err)
 			}
@@ -127,6 +128,7 @@ func Test_cliApp_basic(t *testing.T) {
 
 	runErr := cliApp.Run()
 	assert.Error(t, runErr, "cliApp run should return error")
+	assert.ErrorIs(t, runErr, errTestFailure)
 	assert.ErrorContains(t, runErr, "found 1 failure(s), 1 warning(s)")
 	assert.Equal(
 		t,

--- a/sg/internal/cli/test/cli.go
+++ b/sg/internal/cli/test/cli.go
@@ -1,6 +1,10 @@
 package test
 
-import "github.com/spf13/cobra"
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
 
 // CreateCLI creates the CLI for the test subcommand.
 func CreateCLI() *cobra.Command {
@@ -14,7 +18,12 @@ func CreateCLI() *cobra.Command {
 			app.contextRoot = args[0]
 			app.stdout = cmd.OutOrStdout()
 
-			return app.Run()
+			appRunErr := app.Run()
+			if errors.Is(appRunErr, errTestFailure) {
+				// the test has ran and failed, but we don't want to show help message
+				cmd.SilenceUsage = true
+			}
+			return appRunErr
 		},
 	}
 


### PR DESCRIPTION
We should fail the cli run on test failures. This PR adds two flags for controlling the behaviors:

- by default: cli returns non-zero exit code on failures, returns 0 exit code on succeed or warnings
- if `--fail-on-warn` sets to true, cli returns non-zero exit code on warnings
- if `--no-fail` sets to true, cli returns zero exit code even there are failures