### PR TITLE
Enable validation on loaded configurations from input and return erro…

### DIFF
--- a/sg/internal/cli/test/app.go
+++ b/sg/internal/cli/test/app.go
@@ -99,18 +99,12 @@ func (cliApp *cliApp) Run() error {
 		return fmt.Errorf("read project spec: %w", err)
 	}
 
-	if projectSpec.Files == nil || len(projectSpec.Files) == 0 {
-		return fmt.Errorf("'files' is not correctly spelled, resulting in a non-standard format")
+	if err := projectSpec.Validate(); err != nil {
+		return fmt.Errorf("project spec validation failed: %w", err)
 	}
 
 	var queryResultsList []result.QueryResults
 	for _, target := range projectSpec.Files {
-		if target.Paths == nil || len(target.Paths) == 0 {
-			return fmt.Errorf("'paths' is not correctly spelled, resulting in a non-standard format")
-		}
-		if target.Policies == nil || len(target.Policies) == 0 {
-			return fmt.Errorf("'policies' is not correctly spelled, resulting in a non-standard format")
-		}
 		queryResult, err := cliApp.queryFileTarget(ctx, cliApp.contextRoot, target)
 		if err != nil {
 			return fmt.Errorf("run target (%s): %w", target.Name, err)

--- a/sg/internal/project/types.go
+++ b/sg/internal/project/types.go
@@ -27,6 +27,21 @@ type FileTargetSpec struct {
 	Data []string `json:"data"`
 }
 
+func (ps Spec) Validate() error {
+	if ps.Files == nil || len(ps.Files) == 0 {
+		return fmt.Errorf("at least one file target is required")
+	}
+	for _, target := range ps.Files {
+		if target.Paths == nil || len(target.Paths) == 0 {
+			return fmt.Errorf("file target paths cannot be empty")
+		}
+		if target.Policies == nil || len(target.Policies) == 0 {
+			return fmt.Errorf("file target policies list cannot be empty")
+		}
+	}
+	return nil
+}
+
 // strListOrMap is a helper type to support specifying string value using list or map (keys).
 // When marshaling back to JSON/YAML, it will always be marshaled as an ordered list.
 //


### PR DESCRIPTION
…r when they are not in standardized format.

This PR is a fix for issue https://github.com/Azure/ShieldGuard/issues/32

```yaml
file: #should be files
  - paths: #should be paths
      - ./tempDataAndPolicy
    policy: #should be policies
      - ./tempDataAndPolicy
 ```
Return
`Error: 'files' is not correctly spelled, resulting a non-standard format`


```yaml
files: #should be files
  - path: #should be paths
      - ./tempDataAndPolicy
    policy: #should be policies
      - ./tempDataAndPolicy
 ```
Return
`Error: 'paths' is not correctly spelled, resulting a non-standard format`


```yaml
files: #should be files
  - paths: #should be paths
      - ./tempDataAndPolicy
    policy: #should be policies
      - ./tempDataAndPolicy
```
`Error: 'policies' is not correctly spelled, resulting a non-standard format`

