### PR TITLE
chore: bump golangci-lint version to 1.51

### DIFF
--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -24,5 +24,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.50
+        version: v1.51
         working-directory: sg


### PR DESCRIPTION
GitHub runner is using 1.20 by default now. This version breaks golangci-lint 1.50 . This pr fixed by bumping the version to 1.51 . Ref: https://github.com/golangci/golangci-lint/pull/3414