### PR TITLE
fix: update golangci-lint

### DIFF
--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -24,5 +24,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.51
+        version: v1.55
         working-directory: sg


### PR DESCRIPTION
goangci-lint 1.51 doesn't support newer version of golang. This pull request bumps the tool to 1.55.