### PR TITLE
feat: lockdown github actions versions and permissions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -17,6 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["main"]
+  merge_group:
   schedule:
     - cron: "0 0 * * 1"
 

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -7,7 +7,9 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   dependency-review:

--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -6,6 +6,7 @@ on:
     branches:
     - main
   pull_request:
+  merge_group:
 
 jobs:
   golangci-sg:

--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -7,13 +7,13 @@ on:
     - main
   pull_request:
 
-permissions:
-  contents: read
-
 jobs:
   golangci-sg:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
     - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:

--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -9,20 +9,18 @@ on:
 
 permissions:
   contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
 
 jobs:
   golangci-sg:
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
         go-version: ">=1.21"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
       with:
         version: v1.55
         working-directory: sg

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,12 +5,13 @@ on:
     tags:
     - '*'
 
-permissions:
-  contents: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      # for creating releases
+      contents: write
+
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,16 +12,16 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: 0
     - run: git fetch --force --tags
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
         go-version: ">=1.21"
         cache: true
         cache-dependency-path: sg/go.mod
-    - uses: goreleaser/goreleaser-action@v4
+    - uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
       with:
         distribution: goreleaser
         version: latest

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
       with:
         go-version: ${{ matrix.go-version }}
     - name: Test ${{ matrix.module }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: ["*"]
+  merge_group:
 
 jobs:
   go-test:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -14,6 +14,8 @@ jobs:
         os: [ubuntu-latest]
         module: [sg]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request lockdown the actions versions to commit and specified permissions in job level.

Verified in my fork repo:

- build pr: https://github.com/bcho/ShieldGuard/pull/1
- release build: https://github.com/bcho/ShieldGuard/actions/runs/7630392569/job/20785955079

unit test permissions:

<img width="367" alt="image" src="https://github.com/Azure/ShieldGuard/assets/1975118/fad4fcb1-4891-4ab7-86d0-d52a35234881">

lint test permissions:

<img width="421" alt="image" src="https://github.com/Azure/ShieldGuard/assets/1975118/c08ce1cc-d29b-406e-9489-de05ca4c22af">

release permissions:

<img width="368" alt="image" src="https://github.com/Azure/ShieldGuard/assets/1975118/6d285519-ffc8-421a-a8fb-e0787a3e2cfb">

release artifacts:

<img width="1241" alt="image" src="https://github.com/Azure/ShieldGuard/assets/1975118/cdeeaa83-7021-4fa6-862a-b90cac177e6c">
